### PR TITLE
Add memo-reset function

### DIFF
--- a/sass/_memo.scss
+++ b/sass/_memo.scss
@@ -29,3 +29,12 @@ $Memoization-Table: () !default;
   $private-sassy-maps-supress-warnings: false !global;
   @return $result;
 }
+
+//////////////////////////////
+// Memoization Reset
+//////////////////////////////
+@function memo-reset($module) {
+  $module: "#{$module}";
+  $Memoization-Table: map-merge($Memoization-Table, ($module: null)) !global;
+  @return true;
+}


### PR DESCRIPTION
I work on a framework that use memoisation for looking up settings from our config tree because tree traversal is expensive in sass. 

However because the config tree can change at anytime we need to be able to reset the current memo cache for a module.

This is currently possible with Sassy-Maps with `$Memoization-Table: ();` but it feels hacky.
