### PR TITLE
fixed 'map-get-deep' warning bug

### DIFF
--- a/sass/sassy-maps/_map-get.scss
+++ b/sass/sassy-maps/_map-get.scss
@@ -20,11 +20,11 @@ $private-sassy-maps-suppress-warnings: false !default;
         $get: map-get($get, nth($keys, $i));
 
         @if $get == null {
-          @return map-get-deep-warning($warn, $get);
+          @return map-get-deep-warning($warn, $get, nth($keys, $i));
         }
       }
       @else {
-        @return map-get-deep-warning($warn, $get);
+        @return map-get-deep-warning($warn, $get, nth($keys, $i));
       }
     }
   }
@@ -37,13 +37,13 @@ $private-sassy-maps-suppress-warnings: false !default;
 //
 // Displays a warning if the retrieved value is `null`
 //////////////////////////////
-@function map-get-deep-warning($warn, $get) {
+@function map-get-deep-warning($warn, $get, $key) {
   @if not $private-sassy-maps-suppress-warnings {
     @if $get == null {
       @warn "Map has no value for key search `#{$warn}`";
     }
     @else if type-of($get) != 'map' {
-      @warn "Non-map value found for key search `#{$warn}`, cannot search for key `#{nth($keys, $i)}`";
+      @warn "Non-map value found for key search `#{$warn}`, cannot search for key `#{$key}`";
     }
   }
   @return null;


### PR DESCRIPTION
When searching a key in a non-map value, 'map-get-deep()' delegates to 'map-get-deep-warning()' to log a warning. But, the searched key is not passed correctly, which logs the following error instead:

Line 46 of /Library/Ruby/Gems/2.0.0/gems/sassy-maps-0.4.0/sass/sassy-maps/_map-get.scss: Undefined variable: "$keys".

Fixed this by passing the key to 'map-get-deep-warning()' directly as an argument.

Signed-off-by: Yoannis Jamar yoannis.j@gmail.com
